### PR TITLE
ios9 适配 query Schemes

### DIFF
--- a/com.yoopoon.cordova.plugin.alipay/plugin.xml
+++ b/com.yoopoon.cordova.plugin.alipay/plugin.xml
@@ -85,6 +85,14 @@
 			</dict>
 			
 		</config-file>
+		
+		<!-- ios9 适配 query Schemes -->
+		<config-file target="*-Info.plist" parent="LSApplicationQueriesSchemes">
+			<array>
+				<string>safepay</string>
+				<string>alipay</string>
+			</array>
+		</config-file>
 	    
 	    
 		<!-- build setting header search path $(SRCROOT)/X5 -->


### PR DESCRIPTION
修复无法唤起支付宝应用继续支付的问题
